### PR TITLE
Bug 1069179 — DELETE /registration can take the simplePushURL as a querystring parameter

### DIFF
--- a/source/loop/apis.rst
+++ b/source/loop/apis.rst
@@ -238,7 +238,7 @@ DELETE /registration
 
     Unregister a given simple push-url from the loop server.
 
-    Body parameters:
+    Body or querystring parameters:
 
     - **simplePushURL**, the simple-push endpoint url as defined in
       https://wiki.mozilla.org/WebAPI/SimplePush#Definitions


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1069179
