### PR TITLE
Remove user-unknown as websocket termination code

### DIFF
--- a/source/loop/apis.rst
+++ b/source/loop/apis.rst
@@ -1801,7 +1801,6 @@ timeout                        √         √         The call setup has timed 
 cancel                √                            The calling party has cancelled a pending
                                                    call.
 media-fail                     √                   The called user has declined the call.
-user-unknown                             √         The indicated user id does not exist.
 closed                                   √         The other user's WSS connection closed
                                                    unexpectedly.
 ==================   ======    ======    ======    ========================================


### PR DESCRIPTION
It's not used anywhere; this condition is actually returned via the REST API.  https://bugzilla.mozilla.org/show_bug.cgi?id=1120001 has more details.