### PR TITLE
Mention Docker-based guide for FxA+FxSync self-hosting

### DIFF
--- a/source/howtos/run-fxa.rst
+++ b/source/howtos/run-fxa.rst
@@ -11,6 +11,9 @@ and we don't provide any other packaging or publish official builds yet.
    questions or find any bugs, please don't hesitate to drop by the IRC channel
    or mailing list and let us know.
 
+.. note:: You might also be interested in
+   [this Docker-based self-hosting guide](https://github.com/michielbdejong/fxa-self-hosting)
+   (use at your own risk).
 
 The Firefox Accounts server is hosted in **git** and requires **nodejs**.
 Make sure your system has these, or install them:


### PR DESCRIPTION
Let me know if adding this note to this wiki page makes sense this way.

I noticed the wiki page itself is indeed vastly incomplete (as the existing note states); it only mentions two of the six (depending how you count) necessary services, and doesn't mention how to link them together.

Still, I'm very worried that someone might take my `setup.sh` script without reviewing how it configures the containers, run that on a server, and assume that it'll be secure enough to store their live data in there.

Maybe we can eventually move my guide to this official Mozilla doc at some point, but not before someone else sec-reviews it. :)