### PR TITLE
Add missing documentation of Loop's context parameters, and fix the response details of the refresh command

### DIFF
--- a/source/loop/apis.rst
+++ b/source/loop/apis.rst
@@ -838,9 +838,13 @@ POST /rooms
 
     Request body parameters:
 
-    - **roomName**, The name of the room.
     - **roomOwner**, The room owner name.
     - **maxSize**, The maximum number of people the room can handle.
+
+    At least one of the following two parameters must be supplied:
+
+    - **context**, An encrypted room context string.
+    - **roomName**, The name of the room, this is now obsolete, but remains to support older clients.
 
     Optional parameter:
 
@@ -961,6 +965,7 @@ PATCH /rooms/:token
 
     Optional request body parameters:
 
+    - **context**, An encrypted room context string.
     - **roomName**, The name of the room.
     - **roomOwner**, The room owner name.
     - **maxSize**, The maximum number of people the room can handle.
@@ -1129,11 +1134,10 @@ Refreshing membership in a room
 
     - **action**, Should be "refresh" in that case.
 
-    On success, the endpoint will return a **204 No Content** response.
-
     Potential HTTP error responses include:
 
     - **400 Bad Request:**  Missing or invalid body parameters
+    - **410 Participation has expired:** The referesh did not occur within the specified time period.
 
     Example::
 
@@ -1372,6 +1376,7 @@ GET /rooms/:token
     Response body parameters:
 
     - **roomToken**, The token used to identify this room.
+    - **context**, An encrypted room context string.
     - **roomName**, The name of the room.
     - **roomUrl**, A URL that can be given to other users to allow them to join the room.
     - **roomOwner**, The user-friendly display name indicating the name of the room's owner.
@@ -1456,6 +1461,7 @@ GET /rooms
 
     - **roomToken**, The token used to identify this room.
     - **roomName**, The name of the room.
+    - **context**, An encrypted room context string.
     - **roomUrl**, A URL that can be given to other users to allow them to join the room.
     - **roomOwner**, The user-friendly display name indicating the name of the room's owner.
     - **maxSize**, The maximum number of users allowed in the room at


### PR DESCRIPTION
In starting to look at some changes for the next part of Loop, I noticed that some of the docs haven't been updated for the context additions ([bug 1141105](https://bugzilla.mozilla.org/show_bug.cgi?id=1141105)).

Also, there's a mistake on the return response for the refresh room API - it doesn't return 204, it returns 200 with the parameters already given, and there's an additional expected response.

r? @Natim 