### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/source/heka/index.rst
+++ b/source/heka/index.rst
@@ -22,6 +22,6 @@ It is currently being used at Mozilla in the Marketplace and Sync infrastructure
 Resources
 =========
 
-- Heka documentation: http://heka-docs.readthedocs.org
+- Heka documentation: https://heka-docs.readthedocs.io
 - Heka binaries: https://github.com/mozilla-services/heka/releases
 - Heka source: https://github.com/mozilla-services/heka

--- a/source/token/apis.rst
+++ b/source/token/apis.rst
@@ -119,7 +119,7 @@ Error Responses
 
 All errors are also returned, wherever possible, as json responses following the
 structure `described in Cornice
-<http://cornice.readthedocs.org/en/latest/validation.html#dealing-with-errors>`_.
+<https://cornice.readthedocs.io/en/latest/validation.html#dealing-with-errors>`_.
 
 In cases where generating such a response is not possible (e.g. when a request
 if so malformed as to be unparsable) then the resulting error response will


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.