### PR TITLE
Update instructions for using custom FxA server.

### DIFF
--- a/source/howtos/run-fxa.rst
+++ b/source/howtos/run-fxa.rst
@@ -36,64 +36,41 @@ own content-server:
 - https://github.com/mozilla/fxa-content-server/
 
 Now direct Firefox to use your servers rather than the default, Mozilla-hosted
-ones.  The procedure varies a little between desktop and Android Firefox.
+ones.  The procedure varies a little between desktop and mobile Firefox, and
+may not work on older versions of the browser.
 
-In desktop Firefox, enter "about:config" in the URL bar:
+For desktop Firefox version 52 or later:
+  - Enter "about:config" in the URL bar
+  - Right click anywhere on the "about:config" page and choose *New > String*
+  - Enter "identity.fxaccounts.autoconfig.uri" for the name, and your
+    content-server URL for the value.
+  - Restart Firefox for the change to take effect.
 
-  - if your Firefox version is 52 or later, you can (optionally) configure a
-    custom FxA server by adding a single preference: Right click anywhere on the
-    "about:config" page and choose *New > String*, and enter
-    "identity.fxaccounts.autoconfig.uri" for the name, and your content-server
-    URL for the value.
+Note that this must be set prior to loading the sign-up or sign-in page
+in order to take effect, and its effects are reset on sign-out.
 
-    - Note that this must be set prior to loading the sign-up or sign-in page
-      in order to take effect, and its effects are reset on sign-out.
+For Firefox for iOS version 9.0 or later:
+  - Go to Settings.
+  - Tap on the Version number 5 times.
+  - Tap on "Advance Account Settings"
+  - Enter your content-server URL
+  - Toggle "Use Custom Account Service" to on.
 
-    - Additionally, if this preference is not set, then the rest of these
-      instructions will still work, even if your Firefox version is greater or
-      equal to 52.
-
-  - Otherwise, search for items containing "fxaccounts", and edit them to use
-    your self-hosted URLs:
-
-    - use your auth-server URL to replace "api.accounts.firefox.com" in
-      the following settings:
-
-      - identity.fxaccounts.auth.uri
-
-    - use your content-server URL to replace "accounts.firefox.com" in
-      the following settings:
-
-      - identity.fxaccounts.remote.signin.uri
-      - identity.fxaccounts.remote.signup.uri
-      - identity.fxaccounts.remote.force_auth.uri
-      - identity.fxaccounts.settings.uri
-
-    - You'll also need to run your own sync server -- see below.
-
-    - You might have to restart Firefox for these changes to take effect.
-
-Since Firefox 33, Firefox for Android has supported custom Firefox Account (and
-sync) servers.  For Firefox 44 and later, enter "about:config" in the URL bar,
-search for items containing "fxaccounts", and edit them to use your self-hosted
-URLs:
-
-  - use your auth-server URL to replace "api.accounts.firefox.com" in
-    the following settings:
-
-    - identity.fxaccounts.auth.uri
-
-  - use your content-server URL to replace "accounts.firefox.com" in
-    the following settings:
-
-    - identity.fxaccounts.remote.webchannel.uri
-    - webchannel.allowObject.urlWhitelist
-
-  - optionally, use your oauth- and profile-server URLs to replace
-    "{oauth,profile}.accounts.firefox.com" in
-
-    - identity.fxaccounts.remote.profile.uri
-    - identity.fxaccounts.remote.oauth.uri
+For Firefox for Android version 44 or later:
+  - Enter "about:config" in the URL bar,
+  - Search for items containing "fxaccounts", and edit them to use your
+    self-hosted URLs:
+      - use your auth-server URL to replace "api.accounts.firefox.com" in
+        the following settings:
+        - identity.fxaccounts.auth.uri
+      - use your content-server URL to replace "accounts.firefox.com" in
+        the following settings:
+        - identity.fxaccounts.remote.webchannel.uri
+        - webchannel.allowObject.urlWhitelist
+      - optionally, use your oauth- and profile-server URLs to replace
+        "{oauth,profile}.accounts.firefox.com" in
+        - identity.fxaccounts.remote.profile.uri
+        - identity.fxaccounts.remote.oauth.uri
 
 **Important**: *after* creating the Android account, changes to
 "identity.fxaccounts" prefs will be *ignored*.  (If you need to change the
@@ -101,10 +78,6 @@ prefs, delete the Android account using the *Settings > Sync > Disconnect...*
 menu item, update the pref(s), and sign in again.)  Non-default Firefox Account
 URLs are displayed in the *Settings > Sync* panel in Firefox for Android, so you
 should be able to verify your URL there.
-
-Prior to Firefox 44, a custom add-on was needed to configure Firefox for
-Android.  For Firefox 43 and earlier, see the blog post `How to connect Firefox
-for Android to self-hosted Firefox Account and Firefox Sync servers`_.
 
 Since the Mozilla-hosted sync servers will not trust assertions issued by
 third-party accounts servers, you will also need to :ref:`run your own


### PR DESCRIPTION
This updates the "how to self-host FxA" page with instructions on configuring a custom server in Firefox for iOS, how that version 9.0 is about to ship with such support.

I also removed some historical notes on how to configure it in older versions of Firefox, because I think they dramatically reduce the readability of the page as a whole.  I'm happy to put them back (in a different section) if anyone feels strongly about it.