### PR TITLE
fix failing build due to new PyPI https policy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinxcontrib-seqdiag==0.6.0
 sphinxcontrib-spelling==2.1
 mozilla-sphinx-theme
-pyenchant==1.6.5
+pyenchant


### PR DESCRIPTION
hello Ryan,
for the syncserver guide you already clarified the section on "allowed_issuers" in [january](https://mail.mozilla.org/pipermail/sync-dev/2018-January/001609.html) in the [docs](https://github.com/mozilla-services/docs/commit/2a06ff1c705864a8e930255d15c7cac17dc8c3dd). So I checked why it's not included in the docs yet, despite it saying "latest" version and saw a failing [build](https://readthedocs.org/projects/mozilla-services/builds/6528282/) having a hiccup on the new pypi https only [policy](https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html): `urllib2.HTTPError: HTTP Error 403: SSL is required`

Removing the fixed version on your pyenchant package makes the build succeed with some lexing warnings. I'll make a second pull request for those.

Thank you for the syncserver, it's nice to run this on my own.