### PR TITLE
Add notes about Fenix to the self-hosting docs.

### DIFF
--- a/source/howtos/run-fxa.rst
+++ b/source/howtos/run-fxa.rst
@@ -56,7 +56,11 @@ For Firefox for iOS version 9.0 or later:
   - Enter your content-server URL
   - Toggle "Use Custom Account Service" to on.
 
-For Firefox for Android version 44 or later:
+For Firefox Preview for Android ("Fenix"):
+  - There is not yet support for using a non-Mozilla-hosted account server.
+  - The work is being tracked in a github issue at https://github.com/mozilla-mobile/fenix/issues/3762.
+
+For Firefox for Android ("Fennec") version 44 or later:
   - Enter "about:config" in the URL bar,
   - Search for items containing "fxaccounts", and edit them to use your
     self-hosted URLs:

--- a/source/howtos/run-sync-1.5.rst
+++ b/source/howtos/run-sync-1.5.rst
@@ -135,8 +135,12 @@ Firefox 52 or later, see the documentation on how to :ref:`howto_run_fxa` for
 how to configure your client for both Sync and Firefox Accounts with a single
 preference.
 
-Since Firefox 33, Firefox for Android has supported custom sync servers.  To
-configure Android Firefox 44 and later to talk to your new Sync server, just set
+Firefox Preview for Android ("Fenix") does not yet support using a
+non-Mozilla-hosted sync server. The work is being tracked in a github
+issue at https://github.com/mozilla-mobile/fenix/issues/3762. 
+
+Since Firefox 33, Firefox for Android ("Fennec") has supported custom sync servers.
+To configure Android Firefox 44 and later to talk to your new Sync server, just set
 the "identity.sync.tokenserver.uri" exactly as above **before signing in to
 Firefox Accounts and Sync on your Android device**.
 


### PR DESCRIPTION
This notes that Fenix does not yet support self-hosted sync or account servers. Might help some users avoid frustration because it's *possible* for them to follow the Fennec setup instructions using about:config, but it doesn't work on Fenix.