### PR TITLE
Remove `deleted` attribute from BSO (doesnt exist)

### DIFF
--- a/source/storage/apis-1.5.rst
+++ b/source/storage/apis-1.5.rst
@@ -74,9 +74,6 @@ Example::
       "payload": "{ \"this is\": \"an example\" }"
     }
 
-.. _bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1657536
-.. _issue: https://github.com/mozilla/application-services/issues/3508
-
 Collections
 -----------
 

--- a/source/storage/apis-1.5.rst
+++ b/source/storage/apis-1.5.rst
@@ -63,15 +63,6 @@ Basic Storage Objects have the following fields:
 |               |           |            | This field may be set on write, but is not returned by the    |
 |               |           |            | server.                                                       |
 +---------------+-----------+------------+---------------------------------------------------------------+
-| deleted       | none      | boolean    | Whether this is a "tombstone" (ie, a record that marks the    |
-|               |           |            | fact an item once existed but no longer does). Only exists    |
-|               |           |            | when the value is `true`. There will also be the same flag in |
-|               |           |            | the encrypted payload for the record. This was added in this  |
-|               |           |            | bug_ for desktop and this issue_ for rust so old              |
-|               |           |            | tombstone records will not have this set. The flag was created|
-|               |           |            | so the server can implement hueristics for tombstones without |
-|               |           |            | needing to deduce based on the payload size.                  |
-+---------------+-----------+------------+---------------------------------------------------------------+
 
 
 Example::


### PR DESCRIPTION
## Description

The SyncStorage API does reference an BSO field called `deleted`.  
But I'm pretty sure this feld does not exist (and never existed).

If I try to set it I get an error 400:8 (Invalid BSO, likely due to badly-formed POST data) and it is not returned on normal or deleted records.

The documentation references these two issues:
 - https://bugzilla.mozilla.org/show_bug.cgi?id=1657536
 - https://github.com/mozilla/application-services/issues/3508

Both ended on the inclusion to *not* include the deleted field at the BSO level. 

