### PR TITLE
Docs/sync 3760 rebrand

### DIFF
--- a/source/fxa/index.rst
+++ b/source/fxa/index.rst
@@ -1,10 +1,10 @@
 .. _server_fxa:
 
 =======================
-Firefox Accounts Server
+Mozilla Accounts Server
 =======================
 
-The Firefox Accounts server provides a centralized database of all user
+The Mozilla accounts server provides a centralized database of all user
 accounts for accessing Mozilla-hosted services.
 
 By default, Firefox will use Mozilla's hosted accounts server at `<https://accounts.firefox.com>`_.  This configuration will work well for most use-cases,

--- a/source/howtos/run-fxa.rst
+++ b/source/howtos/run-fxa.rst
@@ -72,7 +72,7 @@ For Firefox for Android ("Fennec") version 44 or later:
         - webchannel.allowObject.urlWhitelist
 
       - optionally, use your oauth- and profile-server URLs to replace
-        `{oauth,profile}.accounts.firefox.com`` in
+        `{oauth,profile}.accounts.firefox.com` in
 
         - identity.fxaccounts.remote.profile.uri
         - identity.fxaccounts.remote.oauth.uri
@@ -98,4 +98,4 @@ review the Mozilla Trademark Policy and Mozilla Branding Guidelines:
 
 You can ask for help on Matrix (chat.mozilla.org) in the #fxa room (https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 
-.. _How to connect Firefox for Android to self-hosted Mozilla account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/
+.. _How to connect Firefox for Android to self-hosted Mozilla Account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/

--- a/source/howtos/run-fxa.rst
+++ b/source/howtos/run-fxa.rst
@@ -98,4 +98,4 @@ review the Mozilla Trademark Policy and Mozilla Branding Guidelines:
 
 You can ask for help on Matrix (chat.mozilla.org) in the #fxa room (https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 
-.. _How to connect Firefox for Android to self-hosted Mozilla Account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/
+.. _How to connect Firefox for Android to self-hosted Mozilla account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/

--- a/source/howtos/run-fxa.rst
+++ b/source/howtos/run-fxa.rst
@@ -1,10 +1,10 @@
 .. _howto_run_fxa:
 
 ====================================
-Run your own Firefox Accounts Server
+Run your own Mozilla accounts server
 ====================================
 
-The Firefox Accounts server is deployed on our systems using RPM packaging,
+The Mozilla accounts server is deployed on our systems using RPM packaging,
 and we don't provide any other packaging or publish official builds yet.
 
 .. note:: This guide is preliminary and vastly incomplete. If you have any
@@ -15,13 +15,13 @@ and we don't provide any other packaging or publish official builds yet.
    `this Docker-based self-hosting guide <https://github.com/michielbdejong/fxa-self-hosting>`_
    (use at your own risk).
 
-The Firefox Accounts server is hosted in **git** and requires **nodejs**.
+The Mozilla accounts server is hosted in **git** and requires **nodejs**.
 Make sure your system has these, or install them:
 
 - git: http://git-scm.com/downloads
 - nodejs: http://nodejs.org/download
 
-A self-hosted Firefox Accounts server requires two components: an auth-server
+A self-hosted Mozilla accounts server requires two components: an auth-server
 that manages the accounts database, and a content-server that hosts a web-based
 user interface.
 
@@ -60,19 +60,19 @@ For Firefox for Android ("Fennec") version 44 or later:
   - Search for items containing "fxaccounts", and edit them to use your
     self-hosted URLs:
 
-      - use your auth-server URL to replace "api.accounts.firefox.com" in
+      - use your auth-server URL to replace `api.accounts.firefox.com` in
         the following settings:
 
         - identity.fxaccounts.auth.uri
 
-      - use your content-server URL to replace "accounts.firefox.com" in
+      - use your content-server URL to replace `accounts.firefox.com` in
         the following settings:
 
         - identity.fxaccounts.remote.webchannel.uri
         - webchannel.allowObject.urlWhitelist
 
       - optionally, use your oauth- and profile-server URLs to replace
-        "{oauth,profile}.accounts.firefox.com" in
+        `{oauth,profile}.accounts.firefox.com`` in
 
         - identity.fxaccounts.remote.profile.uri
         - identity.fxaccounts.remote.oauth.uri
@@ -80,7 +80,7 @@ For Firefox for Android ("Fennec") version 44 or later:
 **Important**: *after* creating the Android account, changes to
 "identity.fxaccounts" prefs will be *ignored*.  (If you need to change the
 prefs, delete the Android account using the *Settings > Sync > Disconnect...*
-menu item, update the pref(s), and sign in again.)  Non-default Firefox Account
+menu item, update the pref(s), and sign in again.)  Non-default Mozilla account
 URLs are displayed in the *Settings > Sync* panel in Firefox for Android, so you
 should be able to verify your URL there.
 
@@ -96,9 +96,6 @@ review the Mozilla Trademark Policy and Mozilla Branding Guidelines:
   - https://www.mozilla.org/en-US/foundation/trademarks/policy/
   - http://www.mozilla.org/en-US/styleguide/identity/mozilla/branding/
 
-You can ask for help:
+You can ask for help on Matrix (chat.mozilla.org) in the #fxa room (https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 
-- on IRC (irc.mozilla.org) in the #fxa channel
-- in our Mailing List: https://mail.mozilla.org/listinfo/dev-fxacct
-
-.. _How to connect Firefox for Android to self-hosted Firefox Account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/
+.. _How to connect Firefox for Android to self-hosted Mozilla account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/

--- a/source/howtos/run-sync-1.5.rst
+++ b/source/howtos/run-sync-1.5.rst
@@ -149,7 +149,7 @@ be able to verify your URL there.
 
 Prior to Firefox 44, a custom add-on was needed to configure Firefox for
 Android.  For Firefox 43 and earlier, see the blog post `How to connect Firefox
-for Android to self-hosted Mozilla Account and Firefox Sync servers`_.
+for Android to self-hosted Mozilla account and Firefox Sync servers`_.
 
 (Prior to Firefox 42, the TokenServer preference name for Firefox Desktop was
 "services.sync.tokenServerURI". While the old preference name will work in
@@ -378,4 +378,4 @@ Don't hesitate to jump online and ask us for help:
 
 - on Element (https://chat.mozilla.org) in the `#sync channel <https://chat.mozilla.org/#/room/#sync:mozilla.org>`_
 
-.. _How to connect Firefox for Android to self-hosted Mozilla Account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/
+.. _How to connect Firefox for Android to self-hosted Mozilla account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/

--- a/source/howtos/run-sync-1.5.rst
+++ b/source/howtos/run-sync-1.5.rst
@@ -149,7 +149,7 @@ be able to verify your URL there.
 
 Prior to Firefox 44, a custom add-on was needed to configure Firefox for
 Android.  For Firefox 43 and earlier, see the blog post `How to connect Firefox
-for Android to self-hosted Mozilla account and Firefox Sync servers`_.
+for Android to self-hosted Mozilla Account and Firefox Sync servers`_.
 
 (Prior to Firefox 42, the TokenServer preference name for Firefox Desktop was
 "services.sync.tokenServerURI". While the old preference name will work in

--- a/source/howtos/run-sync-1.5.rst
+++ b/source/howtos/run-sync-1.5.rst
@@ -13,13 +13,13 @@ any Web Server that supports the `WSGI` protocol.
 Important Notes
 ===============
 
-The sync service uses `Firefox Accounts <https://wiki.mozilla.org/Identity/FirefoxAccounts>`_
+The sync service uses `Mozilla accounts <https://wiki.mozilla.org/Identity/FirefoxAccounts>`_
 for user authentication, which is a separate service and is not covered by this guide.
 
 .. note:: By default, a server set up using this guide will defer authentication
-   to the Mozilla-hosted accounts server at https://accounts.firefox.com.
+   to the Mozilla-hosted accounts server at `https://accounts.firefox.com`.
 
-You can safely use the Mozilla-hosted Firefox Accounts server in combination
+You can safely use the Mozilla-hosted Mozilla accounts server in combination
 with a self-hosted sync storage server.  The authentication and encryption
 protocols are designed so that the account server does not know the user's
 plaintext password, and therefore cannot access their stored sync data.
@@ -124,21 +124,21 @@ to be the public URL of your server with a path of "token/1.0/sync/1.5":
 
   - identity.sync.tokenserver.uri:  http://localhost:5000/token/1.0/sync/1.5
 
-Alternatively, if you're running your own Firefox Accounts server, and running
+Alternatively, if you're running your own Mozilla accounts server, and running
 Firefox 52 or later, see the documentation on how to :ref:`howto_run_fxa` for
-how to configure your client for both Sync and Firefox Accounts with a single
+how to configure your client for both Sync and Mozilla accounts with a single
 preference.
 
 Firefox for Android ("Daylight", versions 79 and later) does support using a 
 non-Mozilla-hosted Sync server. **Before logging in**, go to App Menu > Settings 
 > About Firefox and click the logo 5 times. You should see a "debug menu enabled" 
-notification. Go back to the main menu and you will see two options for a custom 
+notification. Go back to the main menu and you will see two options for a custom
 account server and a custom Sync server. Set the Sync server to the URL given 
 above and then log in.
 
 To configure Android Firefox 44 up to 78 to talk to your new Sync server, just set
 the "identity.sync.tokenserver.uri" exactly as above **before signing in to
-Firefox Accounts and Sync on your Android device**.
+Mozilla accounts and Sync on your Android device**.
 
 **Important**: *after* creating the Android account, changes to
 "identity.sync.tokenserver.uri" will be *ignored*.  (If you need to change the
@@ -149,7 +149,7 @@ be able to verify your URL there.
 
 Prior to Firefox 44, a custom add-on was needed to configure Firefox for
 Android.  For Firefox 43 and earlier, see the blog post `How to connect Firefox
-for Android to self-hosted Firefox Account and Firefox Sync servers`_.
+for Android to self-hosted Mozilla account and Firefox Sync servers`_.
 
 (Prior to Firefox 42, the TokenServer preference name for Firefox Desktop was
 "services.sync.tokenServerURI". While the old preference name will work in
@@ -158,11 +158,11 @@ name will be reset when the user signs out from Sync causing potential
 confusion.)
 
 Since Firefox 18, Firefox for iOS has support for custom sync servers. The settings
-can be made in the Advanced Sync Settings in the Firefox account section, which are
-visible if you are not signed in with a Firefox account and have enabled the debug mode
+can be made in the Advanced Sync Settings in the Mozilla account section, which are
+visible if you are not signed in with a Mozilla account and have enabled the debug mode
 (tap 5 times on the version number). In order to use the custom sync server with Firefox 28,
-the token server's url must not contain the path "/1.0/sync/1.5". It is also important to 
-configure a custom FxA content server (you may use the default https://accounts.firefox.com).
+the token server's url must not contain the path "/1.0/sync/1.5". It is also important to
+configure a custom account content server (you may use the default `https://accounts.firefox.com`).
 
 Further Configuration
 =====================
@@ -189,8 +189,8 @@ Then copy-paste the value into the config file like so::
 The "identity_provider" setting controls which server service can issue
 identity assertions for access to the service.  By default it will accept
 identity assertions from the Mozilla-hosted account server at
-https://accounts.firefox.com.  If you are hosting your own instance of
-Firefox Accounts, you should change this to your own domain:
+`https://accounts.firefox.com`.  If you are hosting your own instance of
+Mozilla accounts, you should change this to your own domain:
 
     [syncserver]
     ...other settings...
@@ -378,4 +378,4 @@ Don't hesitate to jump online and ask us for help:
 
 - on Element (https://chat.mozilla.org) in the `#sync channel <https://chat.mozilla.org/#/room/#sync:mozilla.org>`_
 
-.. _How to connect Firefox for Android to self-hosted Firefox Account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/
+.. _How to connect Firefox for Android to self-hosted Mozilla Account and Firefox Sync servers: http://www.ncalexander.net/blog/2014/07/05/how-to-connect-firefox-for-android-to-self-hosted-services/

--- a/source/storage/apis-1.5.rst
+++ b/source/storage/apis-1.5.rst
@@ -1023,7 +1023,7 @@ The following is a summary of protocol changes from
 +-------------------------------------------+---------------------------------------------------+
 | What Changed                              | Why                                               |
 +===========================================+===================================================+
-| Authentication is now performed using     | This supports authentication via Firefox Accounts |
+| Authentication is now performed using     | This supports authentication via Mozilla accounts |
 | a BrowserID-based tokenserver flow and    | and allows us to iterate the details of that      |
 | HAWK Access Authentication.               | flow without changing the sync protocol.          |
 +-------------------------------------------+---------------------------------------------------+

--- a/source/sync/overview.rst
+++ b/source/sync/overview.rst
@@ -105,7 +105,7 @@ A specific client often targets specific versions of the storage service and
 Storage Limits
 ==============
 
-Each Firefox Account is limited to 2GB of data per *collection*. This affects all Sync Clients associated with that account.
+Each Mozilla account is limited to 2GB of data per *collection*. This affects all Sync Clients associated with that account.
 
 When a Sync Client sends a sync request to a *collection* with greater than 2GB of data, the Sync Server will respond with a specific error code indicating a
 :ref:`User over quota error <respcodes>`.

--- a/source/sync/storageformat5.rst
+++ b/source/sync/storageformat5.rst
@@ -41,7 +41,7 @@ bundle is combined with a per-record 16 byte IV and a user's data is converted
 into ciphertext. The ciphertext is *signed* with the key bundle's **HMAC key**.
 The *ciphertext*, *IV*, and *HMAC value* are then uploaded to the server.
 
-When Sync is initially configured by signing in with a Firefox Account, the
+When Sync is initially configured by signing in with a Mozilla account, the
 client obtains a 256-bit encryption key called the **Class-B Master Key**. This
 key is used to derive a special *key bundle* via HKDF, called the **Sync Key
 Bundle**. The *Sync Key Bundle* is used to encrypt and decrypt a special record
@@ -54,7 +54,7 @@ Terminology
 -----------
 
 Class-B Master Key
-    256-bit encryption key obtained from Firefox Accounts, which effectively serves
+    256-bit encryption key obtained from Mozilla accounts, which effectively serves
     as the master key to Sync.
 
 Key Bundle
@@ -100,8 +100,8 @@ Class-B Master Key
 ------------------
 
 All encryption keys used in Sync are ultimately tied back to the user's
-*Class-B Master Key*, which is managed by Firefox Accounts and obtained
-through the `FxA signin protocol <https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-onepw-protocol>`_
+*Class-B Master Key*, which is managed by Mozilla accounts and obtained
+through the `Accounts/Sync signin protocol <https://mozilla.github.io/ecosystem-platform/explanation/onepw-protocol>`_
 (which refers to this value as "kB").
 All clients that wish to collaborate via Sync share the same value for this key.
 It is important to state that the *Class-B Master Key* or keys derived from it

--- a/source/token/user-flow.rst
+++ b/source/token/user-flow.rst
@@ -2,7 +2,7 @@
 User Flow
 =========
 
-Here's the proposed two-step flow (with BrowserID/FxA assertions):
+Here's the proposed two-step flow (with BrowserID/Mozilla account assertions):
 
 1. the client trades a BrowserID assertion for an :term:`Auth token` and
    corresponding secret


### PR DESCRIPTION
## Description

This rebrands Firefox Accounts to Mozilla Accounts.

Do not land this PR until after Nov 1

## Issue(s)

Closes: SYNC-3760
