### PR TITLE
docs: Remove references to BrowserID

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -58,10 +58,10 @@ Glossary
       This is the only secret shared with the client and is different for each
       auth token.
 
-   Generation Number (obsolete)
-      An integer that may be included in a BrowserID identity certificate.
+   Generation Number
+      An integer that may be included in an identity certificate.
       The issuing server increases this value whenever the user changes
-      their password.  By rejecting BrowserID assertions with a generation
+      their password.  By rejecting assertions with a generation
       number lower than the previously-seen maximum for that user, the
       Login Server can reject assertions generated using an old password.
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -58,7 +58,7 @@ Glossary
       This is the only secret shared with the client and is different for each
       auth token.
 
-   Generation Number
+   Generation Number (obsolete)
       An integer that may be included in a BrowserID identity certificate.
       The issuing server increases this value whenever the user changes
       their password.  By rejecting BrowserID assertions with a generation

--- a/source/token/apis.rst
+++ b/source/token/apis.rst
@@ -12,7 +12,8 @@ Token Server API v1.0
 
     Asks for new token given some credentials in the Authorization header.
 
-    By default, the authentication scheme is BrowserID but other schemes can
+    By default, the authentication scheme is Mozilla Accounts OAuth 2.0
+    but other schemes can
     potentially be used if supported by the login server.
 
     - **app_name** is the name of the application to access, like **sync**.
@@ -22,11 +23,11 @@ Token Server API v1.0
     The first /1.0/ in the URL defines the version of the authentication
     token itself.
 
-    Example for BrowserID::
+    Example for Mozilla Account OAuth 2.0::
 
         GET /1.0/sync/1.5
         Host: token.services.mozilla.com
-        Authorization: BrowserID <assertion>
+        Authorization: bearer <assertion>
 
     This API returns several values in a json mapping:
 
@@ -110,7 +111,7 @@ Response Headers
 
     This header will be included with all "200" and "401" responses, giving
     the current POSIX timestamp as seen by the server, in seconds.  It may
-    be useful for client to adjust their local clock when generating BrowserID
+    be useful for client to adjust their local clock when generating authorization
     assertions.
 
 
@@ -141,7 +142,7 @@ Error status codes and their corresponding output are:
   strings:
 
     - **"invalid-credentials"**: authentication failed due to invalid
-      credentials e.g. a bad signature on the BrowserID assertion.
+      credentials e.g. a bad signature on the Authorization assertion.
     - **"invalid-timestamp"**: authentication failed because the included
       timestamp differed too greatly from the server's current time.
     - **"invalid-generation"**:  authentication failed because the server

--- a/source/token/index.rst
+++ b/source/token/index.rst
@@ -7,6 +7,10 @@ Token Server
 Goal of the Service
 ===================
 
+**Please Note**: BrowserID has been removed from Mozilla Accounts, and
+therefore has also been removed from later versions of Tokenserver. Discussion
+of BrowserID presented here is for historic purposes only.
+
 So here's the challenge we face. Current login for sync looks like this:
 
 1. provide username and password
@@ -20,9 +24,10 @@ node-assignment is lightweight, since the client and server both cache the
 result, and has support for multiple applications with the /node/<app> API
 protocol.
 
-However, this breaks horribly when we don't have centralized login. And adding
-support for browserid to the SyncStorage protocol means that we're now there.
-We're going to get valid requests from users who don't have an account in LDAP.
+However, this breaks horribly when we don't have centralized login. Adding
+support for FxA Authentication to the SyncStorage protocol means that we're now
+there.
+We're going to get valid requests from users who don't have an account in FxA.
 We won't even know, when they make a first request, if the node-assignment
 server has ever heard of them.
 

--- a/source/token/user-flow.rst
+++ b/source/token/user-flow.rst
@@ -2,6 +2,10 @@
 User Flow
 =========
 
+**Please Note**: BrowserID has been removed from Mozilla Accounts, and
+therefore has also been removed from later versions of Tokenserver. Discussion
+of BrowserID presented here is for historic purposes only.
+
 Here's the proposed two-step flow (with BrowserID/Mozilla account assertions):
 
 1. the client trades a BrowserID assertion for an :term:`Auth token` and


### PR DESCRIPTION
## Description

Remove references to active use of BrowserID except for legacy information. 

## Issue(s)

Closes: SYNC-4209